### PR TITLE
add Static Application Security Testing behind 'security-sast'

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,19 @@ make format
 # Format code. e.g Prettier (js), format (golang)
 
 make test
-# Shortcut to launch function tests, integration tests and unit tests. pytest, jest (js), phpunit, JUnit (java) etc ...
+# Shortcut to launch all the test tasks (unit, functional and integration)
 
 make test-unit
+# launch unit tests. e.g. pytest, jest, phpunit, JUnit etc...
+
 make test-functional
+# launch functional tests. e.g behat, JBehave, Behave, CucumberJS, Cucumber etc...
+
 make test-integration
+# launch integration tests. e.g pytest, jest, phpunit etc...
+
+make security-sast
+# launch static application security testing (SAST). e.g Gosec, bandit, Flawfinder, NodeJSScan, phpcs-security-audit, brakeman.
 
 make run
 # Locally run the application, e.g. node index.js, python -m myapp, go run myapp etc ...


### PR DESCRIPTION
Hello,

The idea of this pull-request is to add a bit of security testing in **Gazr**. The first step is to add **"SAST"** _(Static Application Security Testing)_.

More details [on the gitlab documentation](https://docs.gitlab.com/ee/user/project/merge_requests/sast.html).

I suggest putting this static analysis behind `make security-sast`

What do you think @tyrcho @Djiit @kerphi ? 