### PR TITLE
feat: Add "make init" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Docker provides a full integration with Mac, Windows & Linux (ubuntu).
 
 ```bash
 make init
-# Bootstrap your application (fetch some data files, restore a shared volume, make some API calls, request user input etc...
+# Bootstrap your application (fetch some data files, make some API calls, request user input etc...)
 
 make style
 # Check lint, code styling rules. e.g. pylint, phpcs, eslint, style (java) etc ...

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Docker provides a full integration with Mac, Windows & Linux (ubuntu).
 ## Tasks specification through Makefile
 
 ```bash
+make init
+# Bootstrap your application (fetch some data files, restore a shared volume, make some API calls, request user input etc...
+
 make style
 # Check lint, code styling rules. e.g. pylint, phpcs, eslint, style (java) etc ...
 


### PR DESCRIPTION
Adds a `make init` command to the spec.

It should be dedicated to pre-docker / non-docker stuff (e.g. importing a file/db dump from a remote s3, prompting user from some values, making API calls...) before bootstrapping the dev env.

Examples are coming in another PR. Closes #15 .