### PR TITLE
propose adding update specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ make security-sast
 make security-dependency-scan
 # launch a dependency scanning to trigger know vulnerabilities. e.g Retire.js, gemnasium, bundler-audit.
 
+make update
+# update data according the current version of code (data them self have to know against which latest version code used)
+
 make run
 # Locally run the application, e.g. node index.js, python -m myapp, go run myapp etc ...
 


### PR DESCRIPTION
The intent of this proposal is to manage data migration between two version.

In quite small project using ORM maintaining compatibility has a cost where we don't require an HA 24h/24h. Our pattern is to store the latest version of code in use in the database, so deploying a new version looks likes:

* stop the service / or redirect users to a readonly instance
* manage backup data if needs
* launch update (this will impact database models and/or data), the script it self should know what todo according the current version stored in the database and the code version. At the end of that script the version of the database should be update. This as multiples advantages:
  - if you don't know when the deployment in production will occur you can manage multiple update at once automaticly
  - CI can test update procedure on a anonymize data from production
  - dev can have an old database a be read to work quickly without the needs to get the latest prod
* run project
* if every things went well you can start redirect users on the new version